### PR TITLE
Remove unnecessary blank lines.

### DIFF
--- a/man/xcolor.1
+++ b/man/xcolor.1
@@ -1,58 +1,43 @@
 '\" t
 .TH XCOLOR 1 2018
-
 .SH NAME
 xcolor \- lightweight color picker for X11
-
 .SH SYNOPSIS
-
 .B xcolor
 [\fB\-f\fR \fINAME\fR | \fB\-c\fR \fIFORMAT\fR] [\fB\-s\fR [\fISELECTION\fR]] [\fB\-n\fR] [\fB\-v\fR] [\fB\-h\fR]
-
 .SH DESCRIPTION
-
 \fBxcolor\fR is a lightweight color picker for X11. Use mouse to select
 colors visible anywhere on the screen to get their RGB representation.
-
 .PP
 By default, the selected color is printed to the standard output.
-
 .SH OPTIONS
-
 .TP
 .BI \-f " NAME\fR,\fP " \-\-format " NAME"
 Specify output format. Possible values for \fINAME\fR are \fBhex\fR, \fBHEX\fR,
 \fBhex!\fR, \fBHEX!\fR, \fBrgb\fR, and \fBplain\fR. See \fBFORMATTING\fR for an
 explanation of different formatting options. Conflicts with \fB\-\-custom\fR.
-
 .TP
 .BI \-c " FORMAT\fR,\fP " \-\-custom " FORMAT"
 Specify template for custom output format. See \fBCUSTOM FORMATTING\fR for an
 explanation of template syntax. Conflicts with \fB\-\-format\fR.
-
 .TP
 .BI \-s " \fR[\fPSELECTION\fR]\fP\fR,\fP " \-\-selection " \fR[\fPSELECTION\fR]\fP"
 Save output to X11 selection. Possible values for \fISELECTION\fR are
 \fBclipboard\fR, \fBprimary\fR and \fBsecondary\fR. If \fISELECTION\fR
 is not supplied, \fBclipboard\fR is used.
-
 .TP
 .BR \-n ", " \-\-no\-preview
 Disable preview window.
-
 .TP
 .BR \-v ", " \-\-version
 Print version information and exit.
-
 .TP
 .BR \-h ", " \-\-help
 Print help message and exit.
-
 .SH FORMATTING
 By default, the color values are printed in lowercase hexadecimal format. The
 output format can be changed using the \fB\-\-format\fR \fINAME\fR switch. The
 possible \fINAME\fR values are:
-
 .TP
 .B hex
 Lowercase hexadecimal (default)
@@ -71,25 +56,20 @@ Decimal RGB
 .TP
 .B plain
 Decimal with semicolon separators
-
 .PP
 The compact form refers to CSS three-letter color codes as specified by CSS
 Color Module Level 3. If the color is not expressible in three-letter form, the
 regular six-letter form will be used.
-
 .SS CUSTOM FORMATTING
-
 The \fB\-\-format\fR switch provides quick access to some commonly used
 formatting options. However, if custom output formatting is desired, this can be
 achieved using the \fB\-\-custom\fR \fIFORMAT\fR switch. The \fIFORMAT\fR
 parameter specifies a template for the output and supports a simple template
 language.
-
 \fIFORMAT\fR templates can contain special expansions that are written inside
 \fB%\fR{\fI...\fR} blocks. These blocks will be expanded into color values
 according to the specifiers defined inside the block. Here are examples of valid
 format strings and what they might translate to:
-
 .RS
 .TS
 lB lB
@@ -123,21 +103,17 @@ bellow illustrates how we can use these rules to decode a formatting template:
 
 The output is the contents of the red color channel formatted in binary and
 padded with zeroes to be sixteen characters long.
-
 .SH ENVIRONMENT
-
 .TP
 .I XCOLOR_FOREGROUND
 Disable daemon mode. Because of the way selections work in X11, \fBxcolor\fR
 forks into background when \fB\-\-selection\fR mode is used. This behavior can
 be disabled by defining \fIXCOLOR_FOREGROUND\fR environment variable.
-
 .TP
 .I XCOLOR_DISABLE_SHAPE
 Disable the use of shaped preview window. By default, \fBxcolor\fR tries to use
 a round-shaped preview window for displaying the currently selected color. This
 behavior can be disabled by defining \fIXCOLOR_DISABLE_SHAPE\fR environment
 variable.
-
 .SH AUTHORS
 Samuel Laurén <samuel.lauren@iki.fi>


### PR DESCRIPTION
Some of the blank lines in the man page cause excess blank lines to be rendered, which makes the man page a bit harder to read than necessary. This commit removes those blank lines that are not required by mandoc (but does leave some that are required!).