### PR TITLE
Add colored help

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,8 @@
-use clap::{App, Arg};
+use clap::{App, AppSettings, Arg};
 
 pub fn get_cli() -> App<'static, 'static> {
     App::new(env!("CARGO_PKG_NAME"))
+        .setting(AppSettings::ColoredHelp)
         .version(env!("CARGO_PKG_VERSION"))
         .author(env!("CARGO_PKG_AUTHORS"))
         .about(env!("CARGO_PKG_DESCRIPTION"))


### PR DESCRIPTION
Thank you for maintaining this awesome tool in advance. I'm looking for something like this tool for a long time!

Lots of cli tools written in rust have a colored help (`fd`, `bat` etc.). So I think to add this tiny feature to `xcolor` is not a bad idea :)