### PR TITLE
fix: out of bounds errors when ratio is incorrect

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -1,12 +1,12 @@
+use std::num::ParseIntError;
 use std::str::FromStr;
 use std::{fmt, iter};
-use std::num::ParseIntError;
 
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_till1};
 use nom::character::complete::{anychar, digit1};
 use nom::combinator::{all_consuming, complete, map, map_res, opt, value};
-use nom::error::{ParseError, FromExternalError};
+use nom::error::{FromExternalError, ParseError};
 use nom::multi::many0;
 use nom::sequence::{preceded, terminated, tuple};
 use nom::IResult;

--- a/src/location.rs
+++ b/src/location.rs
@@ -60,8 +60,18 @@ fn create_new_cursor(
         let mut cursor_pixels =
             PixelArrayMut::from_raw_parts((*cursor_image).pixels, preview_width as usize);
 
+        // find out how large our pixels should be in the picker - this must be an odd number (so
+        // there's a center pixel) and it must be slightly higher than the ratio between the
+        // cursor and the screenshot (to account for integer division so no out of bounds accesses
+        // occur when upscaling the image in `draw_magnifying_glass`)
+        let mut pixel_size = cursor_pixels.width() / screenshot_pixels.width();
+        if pixel_size % 2 == 0 {
+            pixel_size += 1;
+        } else {
+            pixel_size += 2;
+        }
+
         // draw our custom image
-        let pixel_size = (cursor_pixels.width() / screenshot_pixels.width()).ensure_odd();
         draw_magnifying_glass(&mut cursor_pixels, screenshot_pixels, pixel_size);
 
         // convert our XcursorImage into a cursor


### PR DESCRIPTION
I found a small calculation error where the `pixel_size` (which is the ratio between the screenshot taken and the cursor image size) was too small.

The pixel size must be odd so there's a center pixel, and it must be slightly higher than the real ratio to account for integer division (no floating point accuracy, etc) so we don't get any out of bounds accesses when upscaling the image.

---

You can reproduce the error (on `master`) by running the following:

```bash
for scale in {8..32}; do cargo run -- -S $scale; cargo run -- -S $scale -P 384; done
```

And it no longer errors with this fix. :slightly_smiling_face: 