### PR TITLE
chore: refactor `PixelArray` and make sure cursors are freed after use

### DIFF
--- a/src/draw.rs
+++ b/src/draw.rs
@@ -1,5 +1,5 @@
 use crate::color::ARGB;
-use crate::pixel::{PixelArray, PixelArrayMut};
+use crate::pixel::PixelSquare;
 
 #[inline]
 fn is_inside_circle(x: isize, y: isize, r: isize) -> bool {
@@ -16,8 +16,8 @@ fn border_color(color: ARGB) -> u32 {
 }
 
 pub fn draw_magnifying_glass(
-    cursor: &mut PixelArrayMut<u32>,
-    screenshot: &PixelArray<ARGB>,
+    cursor: &mut PixelSquare<&mut [u32]>,
+    screenshot: &PixelSquare<&[ARGB]>,
     pixel_size: usize,
 ) {
     assert!(pixel_size % 2 != 0, "pixel_size must be odd");

--- a/src/location.rs
+++ b/src/location.rs
@@ -253,6 +253,7 @@ pub fn wait_for_location(
     };
 
     xproto::ungrab_pointer(conn, xbase::CURRENT_TIME);
+    xproto::free_cursor(conn, cursor);
     conn.flush();
 
     Ok(result)

--- a/src/pixel.rs
+++ b/src/pixel.rs
@@ -1,17 +1,18 @@
-use std::ops::{Index, IndexMut};
 use std::slice;
+use std::ops::{Index, IndexMut, Deref, DerefMut};
 
 type Point = (usize, usize);
 
-/// A wrapper struct for a a one-dimensional vector that represents a square of values
-pub struct PixelArray<'a, T> {
-    pixels: &'a [T],
+/// A wrapper struct for a a one-dimensional vector that represents a square of values.
+/// The wrapper makes it easier to index into the array (with `x` and `y` coordinates).
+pub struct PixelSquare<T> {
+    pixels: T,
     width: usize,
 }
 
-impl<'a, T> PixelArray<'a, T> {
-    pub fn new(pixels: &'a [T], width: usize) -> Self {
-        Self { pixels, width }
+impl<T> PixelSquare<T> {
+    pub fn new(pixels: T, width: usize) -> Self {
+        PixelSquare { pixels, width }
     }
 
     pub fn width(&self) -> usize {
@@ -19,63 +20,35 @@ impl<'a, T> PixelArray<'a, T> {
     }
 }
 
-impl<'a, T> Index<usize> for PixelArray<'a, T> {
-    type Output = T;
-    fn index(&self, index: usize) -> &Self::Output {
-        &self.pixels[index]
-    }
-}
-
-impl<'a, T> Index<Point> for PixelArray<'a, T> {
-    type Output = T;
-    fn index(&self, (x, y): Point) -> &Self::Output {
-        &self.pixels[x * self.width + y]
-    }
-}
-
-/// A wrapper struct for a a one-dimensional vector that represents a square of mutable values
-pub struct PixelArrayMut<'a, T> {
-    pixels: &'a mut [T],
-    width: usize,
-}
-
-impl<'a, T> PixelArrayMut<'a, T> {
-    pub fn new(pixels: &'a mut [T], width: usize) -> Self {
-        Self { pixels, width }
-    }
-
+impl<T> PixelSquare<&mut [T]> {
     /// Instantiates a new `PixelArrayMut` from a pointer to a C array
     pub unsafe fn from_raw_parts(data: *mut T, width: usize) -> Self {
         Self::new(slice::from_raw_parts_mut(data, width * width), width)
     }
-
-    pub fn width(&self) -> usize {
-        self.width
-    }
 }
 
-impl<'a, T> Index<usize> for PixelArrayMut<'a, T> {
+impl<T, U: Deref<Target=[T]>> Index<usize> for PixelSquare<U> {
     type Output = T;
-    fn index(&self, index: usize) -> &Self::Output {
-        &self.pixels[index]
+    fn index(&self, idx: usize) -> &Self::Output {
+        &self.pixels[idx]
     }
 }
 
-impl<'a, T> IndexMut<usize> for PixelArrayMut<'a, T> {
-    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-        &mut self.pixels[index]
+impl<T, U: DerefMut<Target=[T]>> IndexMut<usize> for PixelSquare<U> {
+    fn index_mut(&mut self, idx: usize) -> &mut Self::Output {
+        &mut self.pixels[idx]
     }
 }
 
-impl<'a, T> Index<Point> for PixelArrayMut<'a, T> {
+impl<T, U: Deref<Target=[T]>> Index<Point> for PixelSquare<U> {
     type Output = T;
     fn index(&self, (x, y): Point) -> &Self::Output {
         &self.pixels[x * self.width + y]
     }
 }
 
-impl<'a, T> IndexMut<Point> for PixelArrayMut<'a, T> {
+impl<T, U: DerefMut<Target=[T]>> IndexMut<Point> for PixelSquare<U> {
     fn index_mut(&mut self, (x, y): Point) -> &mut Self::Output {
-        &mut self.pixels[(x * self.width + y)]
+        &mut self.pixels[x * self.width + y]
     }
 }


### PR DESCRIPTION
This change allows the user to "zoom" the picker (increase its size and magnification) when pressing right click.

Since `xcolor` already has the `--scale` and `--preview-width` flags already allow the user to configure the picker, rght-clicking will only slightly increase the size.

It also includes a nice refactor to `PixelArray` and `PixelArrayMut` which were previously two structs, but are now combined into a single struct, `PixelSquare`.