### PR TITLE
Only print trailing newline when output is terminal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,6 +229,7 @@ name = "xcolor"
 version = "0.5.1"
 dependencies = [
  "anyhow",
+ "atty",
  "clap",
  "lazy_static",
  "nix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1"
+atty = "0.2"
 nom = "7"
 clap = "2"
 nix = "0.22"

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod selection;
 mod util;
 
 use anyhow::{anyhow, Result};
+use atty::Stream;
 use clap::{value_t, ArgMatches, ErrorKind};
 use nix::unistd::ForkResult;
 use xcb::base::Connection;
@@ -86,7 +87,8 @@ fn run(args: &ArgMatches) -> Result<()> {
                     set_selection(&conn, root, &selection.unwrap(), &output)?;
                 }
             } else {
-                println!("{}", output);
+                let trailing_newline = atty::is(Stream::Stdout).then_some("\n").unwrap_or("");
+                print!("{}{}", output, trailing_newline);
             }
         }
     }


### PR DESCRIPTION
This makes it so the output does *not* have a trailing newline when the
user is piping to another command.

This has the potentially unwanted side effect of removing the newline when
the user is redirecting to a file (`xcolor >> colors.txt`). Feel free to close
the PR if this is not the desired behavior.

Instead of automatically detecting this, it could also be a CLI flag. Or it could be both, with the options `--newline auto|always|never`.

Resolves #44
